### PR TITLE
remove duplicated list entry in hospital table explanation

### DIFF
--- a/frontend/src/components/HospitalTable.vue
+++ b/frontend/src/components/HospitalTable.vue
@@ -192,10 +192,6 @@
                                                 Katecholamintherapie
                                             </li>
                                             <li>
-                                                differenzierte
-                                                Katecholamintherapie
-                                            </li>
-                                            <li>
                                                 kontrollierte invasive Beatmung
                                                 mittels Intensivbeatmungsgeräten
                                                 (über Endotrachealtubus oder


### PR DESCRIPTION
"differenzierte Katecholamintherapie" is duplicated in definition of different levels of intensive care.